### PR TITLE
Fixing multi instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.1.2] - 2020-07-01
-### Added
-- Default blank value for `k8s_kiam_role_arn`.
+## [2.1.3] - 2020-08-05
+### Changed
+- Fix multi instance deployment resource names.
 
 ## [2.1.1] - 2020-06-24
 ### Added

--- a/common.tf
+++ b/common.tf
@@ -6,6 +6,7 @@
 
 locals {
   instance_alias = var.instance_name == "" ? "beekeeper" : format("beekeeper-%s", var.instance_name)
+  queue_alias = var.instance_name == "" ? var.queue_name : "${var.queue_name}-${var.instance_name}"
 }
 
 data "aws_iam_account_alias" "current" {}

--- a/ecs-cloudwatch.tf
+++ b/ecs-cloudwatch.tf
@@ -45,8 +45,8 @@ data "template_file" "sqs_widgets" {
           "height":6,
           "properties":{
              "metrics": [
-                 [ "AWS/SQS", "NumberOfMessagesSent", "QueueName", "${var.queue_name}" ],
-                 [ "AWS/SQS", "NumberOfMessagesReceived", "QueueName", "${var.queue_name}" ]
+                 [ "AWS/SQS", "NumberOfMessagesSent", "QueueName", "${local.queue_alias}" ],
+                 [ "AWS/SQS", "NumberOfMessagesReceived", "QueueName", "${local.queue_alias}" ]
              ],
              "period":300,
              "stat":"Average",
@@ -60,9 +60,9 @@ data "template_file" "sqs_widgets" {
           "height":6,
           "properties":{
         	 "metrics": [
-               [ "AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", "${var.queue_name}" ],
-               [ "AWS/SQS", "ApproximateNumberOfMessagesDelayed", "QueueName", "${var.queue_name}" ],
-               [ "AWS/SQS", "ApproximateNumberOfMessagesNotVisible", "QueueName", "${var.queue_name}" ]
+               [ "AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", "${local.queue_alias}" ],
+               [ "AWS/SQS", "ApproximateNumberOfMessagesDelayed", "QueueName", "${local.queue_alias}" ],
+               [ "AWS/SQS", "ApproximateNumberOfMessagesNotVisible", "QueueName", "${local.queue_alias}" ]
               ],
              "period":300,
              "stat":"Average",
@@ -76,7 +76,7 @@ data "template_file" "sqs_widgets" {
           "height":6,
           "properties":{
              "metrics": [
-               [ "AWS/SQS", "NumberOfMessagesDeleted", "QueueName", "${var.queue_name}" ]
+               [ "AWS/SQS", "NumberOfMessagesDeleted", "QueueName", "${local.queue_alias}" ]
              ],
              "period":300,
              "stat":"Average",
@@ -90,7 +90,7 @@ data "template_file" "sqs_widgets" {
           "height":6,
           "properties":{
              "metrics": [
-                 [ "AWS/SQS", "ApproximateAgeOfOldestMessage", "QueueName", "${var.queue_name}" ]
+                 [ "AWS/SQS", "ApproximateAgeOfOldestMessage", "QueueName", "${local.queue_alias}" ]
              ],
              "period":300,
              "stat":"Average",
@@ -98,7 +98,7 @@ data "template_file" "sqs_widgets" {
              "region": "${var.aws_region}",
              "title": "Beekeeper SQS Age of Oldest Message (s)"
            }
-       }  
+       }
 EOF
 }
 

--- a/lambda-cloudwatch.tf
+++ b/lambda-cloudwatch.tf
@@ -6,7 +6,7 @@
 
 resource "aws_cloudwatch_metric_alarm" "beekeeper_sqs_dlq" {
   count               = var.slack_lambda_enabled == 1 ? 1 : 0
-  alarm_name          = "${var.queue_name}-dlq-alarm"
+  alarm_name          = "${local.queue_alias}-dlq-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -20,6 +20,6 @@ resource "aws_cloudwatch_metric_alarm" "beekeeper_sqs_dlq" {
   tags                = var.beekeeper_tags
 
   dimensions = {
-    QueueName = "${var.queue_name}-dead-letter"
+    QueueName = "${local.queue_alias}-dead-letter"
   }
 }

--- a/rds.tf
+++ b/rds.tf
@@ -5,7 +5,7 @@
  */
 
 resource "aws_db_subnet_group" "beekeeper_db_subnet_group" {
-  name        = "beekeeper-db-subnet-group"
+  name        = "${local.instance_alias}-db-subnet-group"
   subnet_ids  = var.rds_subnets
   description = "Beekeeper DB Subnet Group"
 
@@ -14,7 +14,7 @@ resource "aws_db_subnet_group" "beekeeper_db_subnet_group" {
 }
 
 resource "aws_security_group" "beekeeper_db_sg" {
-  name   = "beekeeper-db"
+  name   = "${local.instance_alias}-db"
   vpc_id = var.vpc_id
   tags   = var.beekeeper_tags
 
@@ -56,13 +56,13 @@ resource "aws_db_instance" "beekeeper" {
   engine                    = "mysql"
   engine_version            = var.rds_engine_version
   instance_class            = var.rds_instance_class
-  name                      = "beekeeper"
+  name                      = local.instance_alias
   username                  = var.db_username
   password                  = chomp(data.aws_secretsmanager_secret_version.beekeeper_db.secret_string)
   parameter_group_name      = var.rds_parameter_group_name
   backup_retention_period   = var.db_backup_retention
   backup_window             = var.db_backup_window
   maintenance_window        = var.db_maintenance_window
-  final_snapshot_identifier = "beekeper-final-snapshot-${random_id.snapshot_id.hex}"
+  final_snapshot_identifier = "${local.instance_alias}-final-snapshot-${random_id.snapshot_id.hex}"
   tags                      = var.beekeeper_tags
 }

--- a/sqs.tf
+++ b/sqs.tf
@@ -5,7 +5,7 @@
  */
 
 resource "aws_sqs_queue" "beekeeper" {
-  name                      = var.queue_name
+  name                      = local.queue_alias
   message_retention_seconds = var.message_retention_seconds
   receive_wait_time_seconds = var.receive_wait_time_seconds
   redrive_policy            = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.beekeeper_dead_letter.arn}\",\"maxReceiveCount\":4}"
@@ -13,7 +13,7 @@ resource "aws_sqs_queue" "beekeeper" {
 }
 
 resource "aws_sqs_queue" "beekeeper_dead_letter" {
-  name                      = "${var.queue_name}-dead-letter"
+  name                      = "${local.queue_alias}-dead-letter"
   message_retention_seconds = var.message_retention_seconds
   receive_wait_time_seconds = var.receive_wait_time_seconds
   tags                      = var.beekeeper_tags


### PR DESCRIPTION
Deploying multiple instance in same AWS account results in name collisions.
Removing hard-coded names for the instance resources and adding queue_alias that will be set up if non-default instance name is provided.